### PR TITLE
Installation instructions  on Fedora Python3

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -282,7 +282,9 @@ Building on Linux
 ^^^^^^^^^^^^^^^^^
 
 If you didn't build Python from source, make sure you have Python's
-development libraries installed. In Debian or Ubuntu::
+development libraries installed. 
+
+In Debian or Ubuntu::
 
     $ sudo apt-get install python-dev python-setuptools
 
@@ -293,6 +295,10 @@ Or for Python 3::
 In Fedora, the command is::
 
     $ sudo dnf install python-devel redhat-rpm-config
+    
+Or for Python 3::
+
+    $ sudo dnf install python3-devel redhat-rpm-config 
 
 .. Note:: ``redhat-rpm-config`` is required on Fedora 23, but not earlier versions.
 


### PR DESCRIPTION
fixes #1981

Changes proposed in this pull request:
      Added installations instructions of Pillow on Fedora Python3
